### PR TITLE
Refactor Full-Line to In-Line Comments + additional cleanup/refactoring

### DIFF
--- a/ABAP Quick Fix Plugin/plugin.xml
+++ b/ABAP Quick Fix Plugin/plugin.xml
@@ -20,6 +20,14 @@
   <extension
          point="com.sap.adt.tools.core.ui.quickAssistProcessors">
          <quickAssistProcessor
+          id="com.abapblog.adt.quickfix.abapQuickFixRFLC"
+          class="com.abapblog.adt.quickfix.assist.comments.ReplaceFullLineWithInlineComment"
+          name="ABAP Quick Assist Processor Replace Fulline with Inline Comments">
+          </quickAssistProcessor>
+   </extension>
+  <extension
+         point="com.sap.adt.tools.core.ui.quickAssistProcessors">
+         <quickAssistProcessor
           id="com.abapblog.adt.quickfix.abapQuickFixRIC"
           class="com.abapblog.adt.quickfix.assist.iconConstants.ReplaceIconsWithConstants"
           name="ABAP Quick Assist Processor Replace Icons With Constants">

--- a/ABAP Quick Fix Plugin/src/com/abapblog/adt/quickfix/assist/comments/AbapQuickFixRemoveCommentsCodeParser.java
+++ b/ABAP Quick Fix Plugin/src/com/abapblog/adt/quickfix/assist/comments/AbapQuickFixRemoveCommentsCodeParser.java
@@ -4,36 +4,47 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class AbapQuickFixRemoveCommentsCodeParser {
-	public static final String multipleEmptyLines = "(\\r?\\n\\r?\\n?(\\r?\\n))+";
-	public static final String singleLineCommentPattern = "(?!\\\"\\!)(?!\\\"#EC )(\\\".*)";
-	public static final String fullLineCommentPattern = "(^(\\*.*)|(\\r\\n\\*.*))";
+	public static final String MULTIPLE_EMPTY_LINES = "(\\r?\\n\\r?\\n?(\\r?\\n))+";
+	public static final String SINGLE_LINE_COMMENT_PATTERN = "(?!\\\"\\!)(?!\\\"#EC )(\\\".*)";
+	public static final String FULL_LINE_COMMENT_PATERN = "(^(\\*.*)|(\\r\\n\\*.*))";
+	public static final String FIRST_CHAR_OF_FULL_LINE_COMMENT = "(^\\*)";
 
-	public Boolean haveComment(String codeText, int start, int end) {
+	public Boolean hasComments(String codeText, int start, int end) {
 		String NewCodeText = codeText.substring(start, end);
 		if (matchFullLineComments(NewCodeText) == true || matchFlexibleComments(NewCodeText) == true) {
 			return true;
 		}
-
 		return false;
-
 	}
-
+	
+	public Boolean hasFullLineComments(String codeText, int start, int end) {
+		Pattern pattern = Pattern.compile(FIRST_CHAR_OF_FULL_LINE_COMMENT, Pattern.MULTILINE);
+		Matcher matcher = pattern.matcher(codeText);
+		return matcher.find();
+	}
+	
 	public String parse(String codeText) {
-
 		return removeComments(codeText);
-
 	}
 
 	private String removeComments(String codeText) {
 		String NewCodeText = codeText;
-		NewCodeText = NewCodeText.replaceAll(fullLineCommentPattern, "");
-		NewCodeText = NewCodeText.replaceAll(singleLineCommentPattern, "");
-		NewCodeText = NewCodeText.replaceAll(multipleEmptyLines, "\r\n\r\n");
+		NewCodeText = NewCodeText.replaceAll(FULL_LINE_COMMENT_PATERN, "");
+		NewCodeText = NewCodeText.replaceAll(SINGLE_LINE_COMMENT_PATTERN, "");
+		NewCodeText = NewCodeText.replaceAll(MULTIPLE_EMPTY_LINES, "\r\n\r\n");
 		return NewCodeText;
+	}
+	
+	public String fullLineCommentsToInLineComments(String codeText) {
+		Pattern pattern = Pattern.compile(FIRST_CHAR_OF_FULL_LINE_COMMENT, Pattern.MULTILINE);
+		Matcher matcher = pattern.matcher(codeText);
+		
+		final String replaceWith = "\"";
+		return matcher.replaceAll(replaceWith);
 	}
 
 	private Boolean matchFlexibleComments(String codeText) {
-		Pattern flexibleCommentPattern = Pattern.compile(singleLineCommentPattern);
+		Pattern flexibleCommentPattern = Pattern.compile(SINGLE_LINE_COMMENT_PATTERN);
 
 		Matcher flexibleCommentMatcher = flexibleCommentPattern.matcher(codeText);
 		while (flexibleCommentMatcher.find()) {
@@ -43,17 +54,12 @@ public class AbapQuickFixRemoveCommentsCodeParser {
 	}
 
 	private Boolean matchFullLineComments(String codeText) {
-		Pattern fullLineCommentsPattern = Pattern.compile(fullLineCommentPattern, Pattern.MULTILINE);
+		Pattern fullLineCommentsPattern = Pattern.compile(FULL_LINE_COMMENT_PATERN, Pattern.MULTILINE);
 
 		Matcher fullLineCommentsMatcher = fullLineCommentsPattern.matcher(codeText);
 		while (fullLineCommentsMatcher.find()) {
 			return true;
 		}
 		return false;
-	}
-
-	static class Match {
-		int start;
-		String text;
 	}
 }

--- a/ABAP Quick Fix Plugin/src/com/abapblog/adt/quickfix/assist/comments/AbapQuickFixRemoveCommentsCodeParser.java
+++ b/ABAP Quick Fix Plugin/src/com/abapblog/adt/quickfix/assist/comments/AbapQuickFixRemoveCommentsCodeParser.java
@@ -18,8 +18,9 @@ public class AbapQuickFixRemoveCommentsCodeParser {
 	}
 	
 	public Boolean hasFullLineComments(String codeText, int start, int end) {
+		String selectedCode = codeText.substring(start,end);
 		Pattern pattern = Pattern.compile(FIRST_CHAR_OF_FULL_LINE_COMMENT, Pattern.MULTILINE);
-		Matcher matcher = pattern.matcher(codeText);
+		Matcher matcher = pattern.matcher(selectedCode);
 		return matcher.find();
 	}
 	

--- a/ABAP Quick Fix Plugin/src/com/abapblog/adt/quickfix/assist/comments/RemoveAllComments.java
+++ b/ABAP Quick Fix Plugin/src/com/abapblog/adt/quickfix/assist/comments/RemoveAllComments.java
@@ -23,7 +23,7 @@ public class RemoveAllComments implements IQuickAssistProcessor {
 		}
 		commentParser = new AbapQuickFixRemoveCommentsCodeParser();
 		String sourceCode = context.getSourceViewer().getDocument().get();
-		return commentParser.haveComment(sourceCode, 0, sourceCode.length());
+		return commentParser.hasComments(sourceCode, 0, sourceCode.length());
 	}
 
 	@Override

--- a/ABAP Quick Fix Plugin/src/com/abapblog/adt/quickfix/assist/comments/RemoveSelectedComments.java
+++ b/ABAP Quick Fix Plugin/src/com/abapblog/adt/quickfix/assist/comments/RemoveSelectedComments.java
@@ -17,15 +17,13 @@ public class RemoveSelectedComments implements IQuickAssistProcessor {
 	public boolean canAssist(IQuickAssistInvocationContext context) {
 		commentParser = new AbapQuickFixRemoveCommentsCodeParser();
 		String sourceCode = context.getSourceViewer().getDocument().get();
-		int lenght = context.getSourceViewer().getSelectedRange().y;
+		int length = context.getSourceViewer().getSelectedRange().y;
 		int offset = context.getSourceViewer().getSelectedRange().x;
-		return commentParser.haveComment(sourceCode, offset, offset + lenght);
-
+		return commentParser.hasComments(sourceCode, offset, offset + length);
 	}
 
 	@Override
 	public boolean canFix(Annotation arg0) {
-		// TODO Auto-generated method stub
 		return false;
 	}
 
@@ -33,14 +31,14 @@ public class RemoveSelectedComments implements IQuickAssistProcessor {
 	public ICompletionProposal[] computeQuickAssistProposals(IQuickAssistInvocationContext context) {
 		List<ICompletionProposal> proposals = new ArrayList<>();
 		if (canAssist(context)) {
-			int lenght = context.getSourceViewer().getSelectedRange().y;
+			int length = context.getSourceViewer().getSelectedRange().y;
 			int offset = context.getSourceViewer().getSelectedRange().x;
 
 			String sourceCode = context.getSourceViewer().getDocument().get();
 
 			Image image = null;
 			CompletionProposal cPropSelectedComments = new CompletionProposal(
-					commentParser.parse(sourceCode.substring( offset, offset + lenght)), offset, lenght, 0, image,
+					commentParser.parse(sourceCode.substring( offset, offset + length)), offset, length, 0, image,
 					"Remove ABAP Comments in selection", null,
 					"Removes all ABAP Comments from the selected code. Please think twice before using it.");
 			proposals.add(cPropSelectedComments);
@@ -52,7 +50,6 @@ public class RemoveSelectedComments implements IQuickAssistProcessor {
 
 	@Override
 	public String getErrorMessage() {
-		// TODO Auto-generated method stub
 		return null;
 	}
 

--- a/ABAP Quick Fix Plugin/src/com/abapblog/adt/quickfix/assist/comments/ReplaceFullLineWithInlineComment.java
+++ b/ABAP Quick Fix Plugin/src/com/abapblog/adt/quickfix/assist/comments/ReplaceFullLineWithInlineComment.java
@@ -1,62 +1,58 @@
 package com.abapblog.adt.quickfix.assist.comments;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.jface.text.contentassist.CompletionProposal;
+import org.eclipse.jface.text.contentassist.ICompletionProposal;
 import org.eclipse.jface.text.quickassist.IQuickAssistInvocationContext;
-import org.eclipse.swt.graphics.Image;
+import org.eclipse.jface.text.quickassist.IQuickAssistProcessor;
+import org.eclipse.jface.text.source.Annotation;
 
-import com.abapblog.adt.quickfix.assist.syntax.statements.IAssistRegex;
-import com.abapblog.adt.quickfix.assist.syntax.statements.StatementAssistRegex;
-
-public class ReplaceFullLineWithInlineComment extends StatementAssistRegex implements IAssistRegex {
-
-	private final String FIRST_CHAR_OF_FULLLINE_COMMENT = "(^\\*)";
-
-	public ReplaceFullLineWithInlineComment(IQuickAssistInvocationContext context) {
-		super(context);
-	}
-
+public class ReplaceFullLineWithInlineComment implements IQuickAssistProcessor {
+	AbapQuickFixRemoveCommentsCodeParser commentParser;
+	
 	@Override
-	public String getChangedCode() {
-		return CodeReader.CurrentStatement.replaceAllPattern(getMatchPattern(), getReplacePattern());
-	}
-
-	@Override
-	public String getAssistShortText() {
-		return "Replace full line comment with in line comment";
-	}
-
-	@Override
-	public String getAssistLongText() {
+	public String getErrorMessage() {
 		return null;
 	}
 
 	@Override
-	public Image getAssistIcon() {
-		return null;
+	public boolean canFix(Annotation annotation) {
+		return false;
 	}
 
 	@Override
-	public boolean canAssist() {
-		return CodeReader.CurrentStatement.matchPattern(getMatchPattern());
+	public boolean canAssist(IQuickAssistInvocationContext invocationContext) {
+		commentParser = new AbapQuickFixRemoveCommentsCodeParser();
+		String sourceCode = invocationContext.getSourceViewer().getDocument().get();
+		int length = invocationContext.getSourceViewer().getSelectedRange().y;
+		int offset = invocationContext.getSourceViewer().getSelectedRange().x;
+		
+		return commentParser.hasFullLineComments(sourceCode, offset, offset + length);
 	}
 
 	@Override
-	public int getStartOfReplace() {
-		return CodeReader.CurrentStatement.getBeginOfStatement();
-	}
+	public ICompletionProposal[] computeQuickAssistProposals(IQuickAssistInvocationContext context) {
+		if (!canAssist(context)) {
+			return null;
+		}
+		List<ICompletionProposal> proposals = new ArrayList<>();
+			int length = context.getSourceViewer().getSelectedRange().y;
+			int offset = context.getSourceViewer().getSelectedRange().x;
+			String sourceCode = context.getSourceViewer().getDocument().get();
 
-	@Override
-	public int getReplaceLength() {
-		return CodeReader.CurrentStatement.getStatementLength();
+			CompletionProposal cPropSelectedComments = new CompletionProposal(
+					commentParser.fullLineCommentsToInLineComments(sourceCode.substring( offset, offset + length)),
+					offset, 
+					length, 
+					0, 
+					null,
+					"Replace full-line with in-line comments in selection", 
+					null,
+					"Replaces all full-line comments in the selected code. Please think twice before using it.");
+			proposals.add(cPropSelectedComments);
+			return proposals.toArray(new ICompletionProposal[1]);
 	}
-
-	@Override
-	public String getMatchPattern() {
-		return FIRST_CHAR_OF_FULLLINE_COMMENT;
-	}
-
-	@Override
-	public String getReplacePattern() {
-		return "\"";
-	}
-
+	
 }

--- a/ABAP Quick Fix Plugin/src/com/abapblog/adt/quickfix/assist/comments/TranslateCommentToEnglish.java
+++ b/ABAP Quick Fix Plugin/src/com/abapblog/adt/quickfix/assist/comments/TranslateCommentToEnglish.java
@@ -25,7 +25,7 @@ public class TranslateCommentToEnglish implements IQuickAssistProcessor {
 			String sourceCode = context.getSourceViewer().getDocument().get();
 			int lenght = context.getSourceViewer().getSelectedRange().y;
 			int offset = context.getSourceViewer().getSelectedRange().x;
-			return commentParser.haveComment(sourceCode, offset, offset + lenght);
+			return commentParser.hasComments(sourceCode, offset, offset + lenght);
 
 		}
 		;

--- a/ABAP Quick Fix Plugin/src/com/abapblog/adt/quickfix/assist/formatter/AlignOperators.java
+++ b/ABAP Quick Fix Plugin/src/com/abapblog/adt/quickfix/assist/formatter/AlignOperators.java
@@ -104,6 +104,9 @@ public class AlignOperators extends StatementAssistAdt {
 		int loopOffset = selectionStart;
 		while (loopOffset <= selectionEnd) {
 			Token currentToken = scannerServices.getNextToken(document, loopOffset);
+			if (currentToken == null) {
+				break;
+			}
 			loopOffset = currentToken.offset + currentToken.name.length();
 			if (isTokenAnOperator(currentToken)) {
 

--- a/ABAP Quick Fix Plugin/src/com/abapblog/adt/quickfix/assist/syntax/statements/StatementsAssistProcessor.java
+++ b/ABAP Quick Fix Plugin/src/com/abapblog/adt/quickfix/assist/syntax/statements/StatementsAssistProcessor.java
@@ -160,8 +160,6 @@ public class StatementsAssistProcessor implements IQuickAssistProcessor {
 		assists.add(new Lt(context));
 		assists.add(new Ne(context));
 		assists.add(new AlignOperators(context));
-		assists.add(new ReplaceFullLineWithInlineComment(context));
-
 	}
 
 	@Override

--- a/ABAP Quick Fix Plugin/src/com/abapblog/adt/quickfix/assist/syntax/statements/global/RemoveFullLineCommentsFromStatement.java
+++ b/ABAP Quick Fix Plugin/src/com/abapblog/adt/quickfix/assist/syntax/statements/global/RemoveFullLineCommentsFromStatement.java
@@ -15,7 +15,7 @@ public class RemoveFullLineCommentsFromStatement extends StatementAssistRegex im
 
 	@Override
 	public String getMatchPattern() {
-		return AbapQuickFixRemoveCommentsCodeParser.fullLineCommentPattern;
+		return AbapQuickFixRemoveCommentsCodeParser.FULL_LINE_COMMENT_PATERN;
 	}
 
 	@Override


### PR DESCRIPTION
- Full-Line to In-Line functionality is now based on the selected code (similar to "remove all abap comments in selection" (closes #28)

- some renaming of methods, typo fixes
- rename of constants to conform to java coding standards (upper case and snake case)

The renames may be controversial, I'd understand if you'd want me to remove that from this PR, let me know